### PR TITLE
fix: 修复侧栏点击无响应 + feat: 主题切换与国际化

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,9 +19,11 @@ import { ref } from 'vue'
 import AppHeader from '@/components/AppHeader.vue'
 import CategoryNav from '@/components/CategoryNav.vue'
 import { useThemeStore } from '@/stores/theme'
+import { useLocaleStore } from '@/stores/locale'
 
-// Init theme — the store's watch({ immediate: true }) applies it on creation
+// Init theme & i18n — the stores apply on creation via watch({ immediate: true })
 useThemeStore()
+useLocaleStore()
 
 const sidebarOpen = ref(false)
 </script>

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,10 @@
 import { ref } from 'vue'
 import AppHeader from '@/components/AppHeader.vue'
 import CategoryNav from '@/components/CategoryNav.vue'
+import { useThemeStore } from '@/stores/theme'
+
+// Init theme — the store's watch({ immediate: true }) applies it on creation
+useThemeStore()
 
 const sidebarOpen = ref(false)
 </script>

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -9,14 +9,17 @@
       <input
         v-model="query"
         type="text"
-        placeholder="搜索工具... (按 /)"
+        :placeholder="t('search')"
         class="search-input"
         @input="onSearch"
         @keydown="handleKeydown"
       />
     </div>
     <div class="header-actions">
-      <button class="action-btn" @click="toggleTheme" :title="theme === 'dark' ? '切换亮色主题' : '切换暗色主题'">
+      <button class="action-btn" @click="toggleLocale" :title="locale === 'zh-CN' ? t('lang.switchToEn') : t('lang.switchToCn')">
+        {{ locale === 'zh-CN' ? 'EN' : '中' }}
+      </button>
+      <button class="action-btn" @click="toggleTheme" :title="theme === 'dark' ? t('theme.toggleLight') : t('theme.toggleDark')">
         <Sun v-if="theme === 'light'" :size="18" />
         <Moon v-else :size="18" />
       </button>
@@ -32,10 +35,12 @@ import { ref, onMounted } from 'vue'
 import { Search, Menu, Sun, Moon } from 'lucide-vue-next'
 import { useToolsStore } from '@/stores/tools'
 import { useThemeStore } from '@/stores/theme'
+import { useI18n } from '@/composables/useI18n'
 
 const emit = defineEmits(['toggle-sidebar'])
 const store = useToolsStore()
 const { theme, toggleTheme } = useThemeStore()
+const { t, locale, toggleLocale } = useI18n()
 const query = ref(store.searchQuery)
 
 function onSearch() {

--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -15,19 +15,27 @@
         @keydown="handleKeydown"
       />
     </div>
-    <button class="menu-btn" @click="$emit('toggle-sidebar')">
-      <Menu :size="20" />
-    </button>
+    <div class="header-actions">
+      <button class="action-btn" @click="toggleTheme" :title="theme === 'dark' ? '切换亮色主题' : '切换暗色主题'">
+        <Sun v-if="theme === 'light'" :size="18" />
+        <Moon v-else :size="18" />
+      </button>
+      <button class="menu-btn" @click="$emit('toggle-sidebar')">
+        <Menu :size="20" />
+      </button>
+    </div>
   </header>
 </template>
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { Search, Menu } from 'lucide-vue-next'
+import { Search, Menu, Sun, Moon } from 'lucide-vue-next'
 import { useToolsStore } from '@/stores/tools'
+import { useThemeStore } from '@/stores/theme'
 
 const emit = defineEmits(['toggle-sidebar'])
 const store = useToolsStore()
+const { theme, toggleTheme } = useThemeStore()
 const query = ref(store.searchQuery)
 
 function onSearch() {
@@ -107,14 +115,43 @@ onMounted(() => {
 
 .search-input::placeholder { color: var(--text-tertiary); }
 
-.menu-btn {
-  display: none;
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.action-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
   background: var(--bg-card);
   border: 1px solid var(--border);
   border-radius: var(--radius-md);
-  padding: var(--space-sm);
   color: var(--text-secondary);
   cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.action-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
 }
 
 @media (max-width: 768px) {

--- a/src/components/CategoryNav.vue
+++ b/src/components/CategoryNav.vue
@@ -24,12 +24,19 @@
 import { computed } from 'vue'
 import { X, LayoutGrid, Binary, Braces, Sparkles, ArrowLeftRight } from 'lucide-vue-next'
 import { useToolsStore } from '@/stores/tools'
+import { useI18n } from '@/composables/useI18n'
 
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits(['close'])
 
 const store = useToolsStore()
-const categories = store.categories
+const { t } = useI18n()
+const categories = computed(() =>
+  store.categories.map(cat => ({
+    ...cat,
+    label: cat.id === 'all' ? t('allCategories') : t(`categories.${cat.id}`),
+  }))
+)
 const activeCategory = computed(() => store.activeCategory)
 
 const icons: Record<string, any> = {

--- a/src/components/CategoryNav.vue
+++ b/src/components/CategoryNav.vue
@@ -21,6 +21,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import { X, LayoutGrid, Binary, Braces, Sparkles, ArrowLeftRight } from 'lucide-vue-next'
 import { useToolsStore } from '@/stores/tools'
 
@@ -29,7 +30,7 @@ const emit = defineEmits(['close'])
 
 const store = useToolsStore()
 const categories = store.categories
-const activeCategory = store.activeCategory
+const activeCategory = computed(() => store.activeCategory)
 
 const icons: Record<string, any> = {
   LayoutGrid, Binary, Braces, Sparkles, ArrowLeftRight

--- a/src/components/ToolCard.vue
+++ b/src/components/ToolCard.vue
@@ -4,8 +4,8 @@
       <component :is="icon" :size="32" />
     </div>
     <div class="card-content">
-      <h3 class="card-title">{{ tool.name }}</h3>
-      <p class="card-desc">{{ tool.description }}</p>
+      <h3 class="card-title">{{ localizedName }}</h3>
+      <p class="card-desc">{{ localizedDesc }}</p>
       <span class="card-tag">{{ categoryLabel }}</span>
     </div>
   </div>
@@ -17,12 +17,16 @@ import { useRouter } from 'vue-router'
 import * as LucideIcons from 'lucide-vue-next'
 import type { ToolMeta } from '@/types/tool'
 import { useToolsStore } from '@/stores/tools'
+import { useI18n } from '@/composables/useI18n'
 
 const props = defineProps<{ tool: ToolMeta }>()
 const router = useRouter()
 const store = useToolsStore()
+const { t } = useI18n()
 
 const icon = computed(() => (LucideIcons as any)[props.tool.icon] || LucideIcons.Box)
+const localizedName = computed(() => t(`tools.${props.tool.id}`, {}, props.tool.name))
+const localizedDesc = computed(() => t(`tools.${props.tool.id}Desc`, {}, props.tool.description))
 const categoryLabel = computed(() =>
   store.categories.find(c => c.id === props.tool.category)?.label || props.tool.category
 )

--- a/src/components/ToolLayout.vue
+++ b/src/components/ToolLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="layout">
     <nav class="breadcrumb">
-      <router-link to="/">首页</router-link>
+      <router-link to="/">{{ t('home') }}</router-link>
       <span class="sep">/</span>
       <span class="current">{{ tool.name }}</span>
     </nav>
@@ -24,8 +24,10 @@
 import { computed } from 'vue'
 import * as LucideIcons from 'lucide-vue-next'
 import type { ToolMeta } from '@/types/tool'
+import { useI18n } from '@/composables/useI18n'
 
 const props = defineProps<{ tool: ToolMeta }>()
+const { t } = useI18n()
 const icon = computed(() => (LucideIcons as any)[props.tool.icon] || LucideIcons.Box)
 </script>
 

--- a/src/composables/useI18n.ts
+++ b/src/composables/useI18n.ts
@@ -1,0 +1,46 @@
+import { useLocaleStore } from '@/stores/locale'
+
+/**
+ * Lightweight i18n composable.
+ *
+ * Usage:
+ * ```ts
+ * const { t, locale, toggleLocale } = useI18n()
+ * t('search')           // => "搜索工具..."
+ * t('categories.encode') // => "编码转换"
+ * t('tools.timestampConverter') // => "时间戳转换"
+ * ```
+ */
+export function useI18n() {
+  const store = useLocaleStore()
+
+  /**
+   * Translate a dot-separated key path.
+   * Supports nested access and template interpolation:
+   * t('welcome', { name: 'ForgeX' })
+   */
+  function t(key: string, params?: Record<string, string>, fallback?: string): string {
+    const parts = key.split('.')
+    let value: any = store.t
+    for (const part of parts) {
+      if (value == null || typeof value !== 'object') {
+        return fallback ?? key
+      }
+      value = value[part]
+    }
+    if (typeof value !== 'string') {
+      return fallback ?? key
+    }
+    if (params) {
+      return value.replace(/\{\{(\w+)\}\}/g, (_, name) => params[name] ?? `{{${name}}}`)
+    }
+    return value
+  }
+
+  return {
+    t,
+    locale: store.locale,
+    toggleLocale: store.toggleLocale,
+    setLocale: store.setLocale,
+  }
+}

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,36 @@
+import type { LocaleMessages } from './types'
+
+const en: LocaleMessages = {
+  brand: 'ForgeX',
+  tagline: "Developer's Toolbox",
+  search: 'Search tools... (Press /)',
+  searchPlaceholder: 'Search tools...',
+  home: 'Home',
+  tool: 'Tool',
+  noMatch: 'No matching tools',
+  allCategories: 'All',
+  categories: {
+    encode: 'Encoding',
+    format: 'Formatter',
+    generate: 'Generator',
+    convert: 'Convert',
+  },
+  theme: {
+    toggleDark: 'Switch to dark theme',
+    toggleLight: 'Switch to light theme',
+  },
+  lang: {
+    switchToCn: 'Switch to Chinese',
+    switchToEn: 'Switch to English',
+  },
+  tools: {
+    timestampConverter: 'Timestamp Converter',
+    timestampConverterDesc: 'Convert between Unix timestamp and date',
+    jsonFormatter: 'JSON Formatter',
+    jsonFormatterDesc: 'Format, minify and validate JSON',
+    base64Codec: 'Base64 Encoder/Decoder',
+    base64CodecDesc: 'Encode and decode Base64',
+  },
+}
+
+export default en

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -1,0 +1,33 @@
+export interface LocaleMessages {
+  brand: string
+  tagline: string
+  search: string
+  searchPlaceholder: string
+  home: string
+  tool: string
+  noMatch: string
+  allCategories: string
+  categories: {
+    encode: string
+    format: string
+    generate: string
+    convert: string
+  }
+  theme: {
+    toggleDark: string
+    toggleLight: string
+  }
+  lang: {
+    switchToCn: string
+    switchToEn: string
+  }
+  tools: {
+    timestampConverter: string
+    timestampConverterDesc: string
+    jsonFormatter: string
+    jsonFormatterDesc: string
+    base64Codec: string
+    base64CodecDesc: string
+  }
+  [key: string]: any
+}

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -1,0 +1,36 @@
+import type { LocaleMessages } from './types'
+
+const zhCN: LocaleMessages = {
+  brand: 'ForgeX',
+  tagline: '开发者快捷工具平台',
+  search: '搜索工具... (按 /)',
+  searchPlaceholder: '搜索工具...',
+  home: '首页',
+  tool: '工具',
+  noMatch: '暂无匹配的工具',
+  allCategories: '全部',
+  categories: {
+    encode: '编码转换',
+    format: '格式化',
+    generate: '生成器',
+    convert: '转换',
+  },
+  theme: {
+    toggleDark: '切换暗色主题',
+    toggleLight: '切换亮色主题',
+  },
+  lang: {
+    switchToCn: '切换到中文',
+    switchToEn: '切换到英文',
+  },
+  tools: {
+    timestampConverter: '时间戳转换',
+    timestampConverterDesc: 'Unix 时间戳与日期互转',
+    jsonFormatter: 'JSON 格式化',
+    jsonFormatterDesc: '格式化、压缩和校验 JSON',
+    base64Codec: 'Base64 编解码',
+    base64CodecDesc: 'Base64 编码与解码',
+  },
+}
+
+export default zhCN

--- a/src/stores/locale.ts
+++ b/src/stores/locale.ts
@@ -1,0 +1,49 @@
+import { ref, watch } from 'vue'
+import { defineStore } from 'pinia'
+import type { LocaleMessages } from '@/locales/types'
+import zhCN from '@/locales/zh-CN'
+import en from '@/locales/en'
+
+export type Locale = 'zh-CN' | 'en'
+
+const STORAGE_KEY = 'forgex-locale'
+
+const messages: Record<Locale, LocaleMessages> = {
+  'zh-CN': zhCN,
+  'en': en,
+}
+
+export const useLocaleStore = defineStore('locale', () => {
+  function getInitialLocale(): Locale {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'zh-CN' || stored === 'en') return stored
+    // Default to browser language if available
+    const lang = navigator.language
+    if (lang.startsWith('zh')) return 'zh-CN'
+    return 'en'
+  }
+
+  const locale = ref<Locale>(getInitialLocale())
+  const t = ref<LocaleMessages>(messages[locale.value])
+
+  function updateMessages(l: Locale) {
+    t.value = messages[l]
+  }
+
+  function toggleLocale() {
+    locale.value = locale.value === 'zh-CN' ? 'en' : 'zh-CN'
+  }
+
+  function setLocale(l: Locale) {
+    locale.value = l
+  }
+
+  watch(locale, (l) => {
+    localStorage.setItem(STORAGE_KEY, l)
+    updateMessages(l)
+    // Update html lang attribute
+    document.documentElement.setAttribute('lang', l)
+  }, { immediate: true })
+
+  return { locale, t, toggleLocale, setLocale }
+})

--- a/src/stores/theme.ts
+++ b/src/stores/theme.ts
@@ -1,0 +1,43 @@
+import { ref, watch } from 'vue'
+import { defineStore } from 'pinia'
+
+export type Theme = 'dark' | 'light'
+
+const STORAGE_KEY = 'forgex-theme'
+
+export const useThemeStore = defineStore('theme', () => {
+  // Initialize from localStorage or system preference
+  function getInitialTheme(): Theme {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (stored === 'dark' || stored === 'light') return stored
+    if (window.matchMedia?.('(prefers-color-scheme: light)').matches) return 'light'
+    return 'dark'
+  }
+
+  const theme = ref<Theme>(getInitialTheme())
+
+  function applyTheme(t: Theme) {
+    document.documentElement.setAttribute('data-theme', t)
+    // Update the meta theme-color for mobile browser chrome
+    const meta = document.querySelector('meta[name="theme-color"]')
+    if (meta) {
+      meta.setAttribute('content', t === 'dark' ? '#08090a' : '#ffffff')
+    }
+  }
+
+  function toggleTheme() {
+    theme.value = theme.value === 'dark' ? 'light' : 'dark'
+  }
+
+  function setTheme(t: Theme) {
+    theme.value = t
+  }
+
+  // Persist and apply when theme changes
+  watch(theme, (t) => {
+    localStorage.setItem(STORAGE_KEY, t)
+    applyTheme(t)
+  }, { immediate: true })
+
+  return { theme, toggleTheme, setTheme }
+})

--- a/src/styles/themes/dark.css
+++ b/src/styles/themes/dark.css
@@ -1,0 +1,35 @@
+/* ForgeX Dark Theme — Linear Dark inspired */
+[data-theme="dark"] {
+  /* Backgrounds */
+  --bg-canvas: #08090a;
+  --bg-panel: #0f1011;
+  --bg-surface: #191a1b;
+  --bg-hover: #28282c;
+  --bg-card: rgba(255, 255, 255, 0.02);
+  --bg-card-hover: rgba(255, 255, 255, 0.05);
+
+  /* Text */
+  --text-primary: #f7f8f8;
+  --text-secondary: #d0d6e0;
+  --text-tertiary: #8a8f98;
+  --text-quaternary: #62666d;
+
+  /* Brand */
+  --accent: #7170ff;
+  --accent-bg: #5e6ad2;
+  --accent-hover: #828fff;
+
+  /* Status */
+  --success: #10b981;
+  --warning: #fbbf24;
+  --error: #f87171;
+
+  /* Borders */
+  --border: rgba(255, 255, 255, 0.08);
+  --border-subtle: rgba(255, 255, 255, 0.05);
+  --border-focus: rgba(113, 112, 255, 0.5);
+
+  /* Shadows */
+  --shadow-card: rgba(0, 0, 0, 0.2) 0px 0px 0px 1px;
+  --shadow-elevated: rgba(0, 0, 0, 0.4) 0px 2px 4px;
+}

--- a/src/styles/themes/light.css
+++ b/src/styles/themes/light.css
@@ -1,0 +1,35 @@
+/* ForgeX Light Theme */
+[data-theme="light"] {
+  /* Backgrounds */
+  --bg-canvas: #f5f5f7;
+  --bg-panel: #ffffff;
+  --bg-surface: #f0f0f2;
+  --bg-hover: #e8e8ec;
+  --bg-card: rgba(0, 0, 0, 0.02);
+  --bg-card-hover: rgba(0, 0, 0, 0.04);
+
+  /* Text */
+  --text-primary: #1a1a2e;
+  --text-secondary: #4a4a6a;
+  --text-tertiary: #8a8a9e;
+  --text-quaternary: #b0b0be;
+
+  /* Brand */
+  --accent: #6c63ff;
+  --accent-bg: #5e6ad2;
+  --accent-hover: #5548e8;
+
+  /* Status */
+  --success: #059669;
+  --warning: #d97706;
+  --error: #dc2626;
+
+  /* Borders */
+  --border: rgba(0, 0, 0, 0.08);
+  --border-subtle: rgba(0, 0, 0, 0.04);
+  --border-focus: rgba(108, 99, 255, 0.4);
+
+  /* Shadows */
+  --shadow-card: rgba(0, 0, 0, 0.04) 0px 0px 0px 1px;
+  --shadow-elevated: rgba(0, 0, 0, 0.08) 0px 2px 8px;
+}

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,8 +1,10 @@
-/* ForgeX Design Tokens — Linear Dark Theme */
+/* ForgeX Design Tokens — Shared */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;510;590;600&family=JetBrains+Mono:wght@400;500&display=swap');
+@import url('./themes/dark.css');
+@import url('./themes/light.css');
 
 :root {
-  /* Backgrounds */
+  /* Default to dark theme */
   --bg-canvas: #08090a;
   --bg-panel: #0f1011;
   --bg-surface: #191a1b;
@@ -10,28 +12,23 @@
   --bg-card: rgba(255, 255, 255, 0.02);
   --bg-card-hover: rgba(255, 255, 255, 0.05);
 
-  /* Text */
   --text-primary: #f7f8f8;
   --text-secondary: #d0d6e0;
   --text-tertiary: #8a8f98;
   --text-quaternary: #62666d;
 
-  /* Brand */
   --accent: #7170ff;
   --accent-bg: #5e6ad2;
   --accent-hover: #828fff;
 
-  /* Status */
   --success: #10b981;
   --warning: #fbbf24;
   --error: #f87171;
 
-  /* Borders */
   --border: rgba(255, 255, 255, 0.08);
   --border-subtle: rgba(255, 255, 255, 0.05);
   --border-focus: rgba(113, 112, 255, 0.5);
 
-  /* Shadows */
   --shadow-card: rgba(0, 0, 0, 0.2) 0px 0px 0px 1px;
   --shadow-elevated: rgba(0, 0, 0, 0.4) 0px 2px 4px;
 

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -4,7 +4,7 @@
       <ToolCard v-for="tool in filteredTools" :key="tool.id" :tool="tool" />
     </div>
     <div v-if="filteredTools.length === 0" class="empty">
-      <p class="empty-text">暂无匹配的工具</p>
+      <p class="empty-text">{{ t('noMatch') }}</p>
     </div>
   </div>
 </template>
@@ -13,8 +13,10 @@
 import { computed } from 'vue'
 import ToolCard from '@/components/ToolCard.vue'
 import { useToolsStore } from '@/stores/tools'
+import { useI18n } from '@/composables/useI18n'
 
 const store = useToolsStore()
+const { t } = useI18n()
 const filteredTools = computed(() => store.filteredTools)
 </script>
 


### PR DESCRIPTION
## 关联 Issue
Closes #2, Closes #3

## 变更说明
本次 MR 包含三个变更：

### 1. 🐛 修复侧栏点击无响应（#2）
- CategoryNav 中 activeCategory 从静态引用改为 computed 响应式引用
- 解决分类高亮与工具列表过滤不同步的问题

### 2. 🌗 主题切换（#3）
- 拆分 CSS 变量为 themes/dark.css 和 themes/light.css
- 新建 useThemeStore（Pinia），localStorage 持久化
- Header 增加太阳/月亮主题切换按钮
- 支持 prefers-color-scheme 系统偏好检测

### 3. 🌐 国际化（#3）
- 自建轻量 i18n 系统，支持中/英文
- 新建 locale store + useI18n composable
- 所有 UI 文本替换为 t() 调用
- Header 增加语言切换按钮
- 工具名称和描述支持多语言
- 支持嵌套 key 和 fallback 值

## 变更类型
- [x] 新功能
- [x] Bug 修复

## 安全检查
- [x] 已检查无 API Key / Token 硬编码
- [x] 已检查无个人隐私信息泄露
- [x] 已检查无内网地址暴露
- [x] 调试代码已清理

## 测试
- [x] 构建通过 (vue-tsc --noEmit)