### PR TITLE
fix: 修复主题/语言切换按钮无响应和侧栏分类点击不跳转

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -16,11 +16,11 @@
       />
     </div>
     <div class="header-actions">
-      <button class="action-btn" @click="toggleLocale" :title="locale === 'zh-CN' ? t('lang.switchToEn') : t('lang.switchToCn')">
-        {{ locale === 'zh-CN' ? 'EN' : '中' }}
+      <button class="action-btn" @click="storeLocale.toggleLocale()" :title="storeLocale.locale === 'zh-CN' ? t('lang.switchToEn') : t('lang.switchToCn')">
+        {{ storeLocale.locale === 'zh-CN' ? 'EN' : '中' }}
       </button>
-      <button class="action-btn" @click="toggleTheme" :title="theme === 'dark' ? t('theme.toggleLight') : t('theme.toggleDark')">
-        <Sun v-if="theme === 'light'" :size="18" />
+      <button class="action-btn" @click="storeTheme.toggleTheme()" :title="storeTheme.theme === 'dark' ? t('theme.toggleLight') : t('theme.toggleDark')">
+        <Sun v-if="storeTheme.theme === 'light'" :size="18" />
         <Moon v-else :size="18" />
       </button>
       <button class="menu-btn" @click="$emit('toggle-sidebar')">
@@ -35,12 +35,14 @@ import { ref, onMounted } from 'vue'
 import { Search, Menu, Sun, Moon } from 'lucide-vue-next'
 import { useToolsStore } from '@/stores/tools'
 import { useThemeStore } from '@/stores/theme'
+import { useLocaleStore } from '@/stores/locale'
 import { useI18n } from '@/composables/useI18n'
 
 const emit = defineEmits(['toggle-sidebar'])
 const store = useToolsStore()
-const { theme, toggleTheme } = useThemeStore()
-const { t, locale, toggleLocale } = useI18n()
+const storeTheme = useThemeStore()
+const storeLocale = useLocaleStore()
+const { t } = useI18n()
 const query = ref(store.searchQuery)
 
 function onSearch() {

--- a/src/components/CategoryNav.vue
+++ b/src/components/CategoryNav.vue
@@ -22,6 +22,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useRouter } from 'vue-router'
 import { X, LayoutGrid, Binary, Braces, Sparkles, ArrowLeftRight } from 'lucide-vue-next'
 import { useToolsStore } from '@/stores/tools'
 import { useI18n } from '@/composables/useI18n'
@@ -29,6 +30,7 @@ import { useI18n } from '@/composables/useI18n'
 const props = defineProps<{ open: boolean }>()
 const emit = defineEmits(['close'])
 
+const router = useRouter()
 const store = useToolsStore()
 const { t } = useI18n()
 const categories = computed(() =>
@@ -45,6 +47,7 @@ const icons: Record<string, any> = {
 
 function selectCategory(id: string) {
   store.setActiveCategory(id)
+  router.push('/')
   emit('close')
 }
 </script>


### PR DESCRIPTION
## 关联 Issue
Closes #5

## 变更说明

### Bug 1: 主题/语言切换按钮点击无响应
从 Pinia store / composable 解构出的方法在模板 @click 中绑定时会丢失上下文。改用完整 store 引用调用（如 `storeTheme.toggleTheme()`），确保方法正确执行。

### Bug 2: 进入工具页面后侧栏分类点击不跳转
`CategoryNav.selectCategory()` 只调用了 `store.setActiveCategory(id)` 和关闭侧栏，未导航到首页。增加 `router.push('/')`，点击分类后回到首页并展示过滤后的工具列表。

## 变更类型
- [x] Bug 修复

## 安全检查
- [x] 已检查无敏感信息泄露
- [x] 调试代码已清理

## 测试
- [x] 构建通过 (vue-tsc --noEmit)