### PR TITLE
fix: 工具内部 UI 文本未国际化

### DIFF
--- a/src/components/ToolLayout.vue
+++ b/src/components/ToolLayout.vue
@@ -3,15 +3,15 @@
     <nav class="breadcrumb">
       <router-link to="/">{{ t('home') }}</router-link>
       <span class="sep">/</span>
-      <span class="current">{{ tool.name }}</span>
+      <span class="current">{{ localizedName }}</span>
     </nav>
     <header class="header">
       <div class="header-icon">
         <component :is="icon" :size="24" />
       </div>
       <div class="header-info">
-        <h1 class="title">{{ tool.name }}</h1>
-        <p class="desc">{{ tool.description }}</p>
+        <h1 class="title">{{ localizedName }}</h1>
+        <p class="desc">{{ localizedDesc }}</p>
       </div>
     </header>
     <div class="content">
@@ -29,6 +29,8 @@ import { useI18n } from '@/composables/useI18n'
 const props = defineProps<{ tool: ToolMeta }>()
 const { t } = useI18n()
 const icon = computed(() => (LucideIcons as any)[props.tool.icon] || LucideIcons.Box)
+const localizedName = computed(() => t(`tools.${props.tool.id}`, {}, props.tool.name))
+const localizedDesc = computed(() => t(`tools.${props.tool.id}Desc`, {}, props.tool.description))
 </script>
 
 <style scoped>

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -31,6 +31,46 @@ const en: LocaleMessages = {
     base64Codec: 'Base64 Encoder/Decoder',
     base64CodecDesc: 'Encode and decode Base64',
   },
+
+  /* Tool internal UI text */
+  timestamp: {
+    label: 'Timestamp',
+    placeholder: 'Enter timestamp (seconds or milliseconds)',
+    toDate: 'Convert to Date',
+    dateTime: 'Date & Time',
+    placeholderDate: 'Enter date (YYYY-MM-DD HH:mm:ss)',
+    toTimestamp: 'Convert to Timestamp',
+    currentTs: 'Current Timestamp',
+    currentTime: 'Current Time',
+    result: 'Result',
+    errInput: 'Please enter a timestamp',
+    errInvalid: 'Invalid timestamp',
+    errDatetime: 'Please enter a date & time',
+    errInvalidDate: 'Invalid date format',
+    seconds: 'seconds',
+    milliseconds: 'milliseconds',
+  },
+  jsonFormatter: {
+    label: 'Input JSON',
+    placeholder: 'Paste JSON content...',
+    format: 'Format',
+    minify: 'Minify',
+    copy: 'Copy',
+    clear: 'Clear',
+    output: 'Output',
+    errParse: 'Parse error',
+  },
+  base64Codec: {
+    label: 'Input',
+    placeholder: 'Enter content to encode/decode...',
+    encode: 'Encode → Base64',
+    decode: 'Decode ← Base64',
+    copy: 'Copy',
+    clear: 'Clear',
+    output: 'Output',
+    errEncode: 'Encode error',
+    errDecode: 'Decode error: please enter a valid Base64 string',
+  },
 }
 
 export default en

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -29,5 +29,43 @@ export interface LocaleMessages {
     base64Codec: string
     base64CodecDesc: string
   }
+  timestamp: {
+    label: string
+    placeholder: string
+    toDate: string
+    dateTime: string
+    placeholderDate: string
+    toTimestamp: string
+    currentTs: string
+    currentTime: string
+    result: string
+    errInput: string
+    errInvalid: string
+    errDatetime: string
+    errInvalidDate: string
+    seconds: string
+    milliseconds: string
+  }
+  jsonFormatter: {
+    label: string
+    placeholder: string
+    format: string
+    minify: string
+    copy: string
+    clear: string
+    output: string
+    errParse: string
+  }
+  base64Codec: {
+    label: string
+    placeholder: string
+    encode: string
+    decode: string
+    copy: string
+    clear: string
+    output: string
+    errEncode: string
+    errDecode: string
+  }
   [key: string]: any
 }

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -31,6 +31,46 @@ const zhCN: LocaleMessages = {
     base64Codec: 'Base64 编解码',
     base64CodecDesc: 'Base64 编码与解码',
   },
+
+  /* 工具内部 UI 文本 */
+  timestamp: {
+    label: '时间戳',
+    placeholder: '输入时间戳 (秒或毫秒)',
+    toDate: '转换为日期',
+    dateTime: '日期时间',
+    placeholderDate: '输入日期 (YYYY-MM-DD HH:mm:ss)',
+    toTimestamp: '转换为时间戳',
+    currentTs: '当前时间戳',
+    currentTime: '当前时间',
+    result: '转换结果',
+    errInput: '请输入时间戳',
+    errInvalid: '无效的时间戳',
+    errDatetime: '请输入日期时间',
+    errInvalidDate: '无效的日期格式',
+    seconds: '秒',
+    milliseconds: '毫秒',
+  },
+  jsonFormatter: {
+    label: '输入 JSON',
+    placeholder: '粘贴 JSON 内容...',
+    format: '格式化',
+    minify: '压缩',
+    copy: '复制',
+    clear: '清空',
+    output: '输出结果',
+    errParse: '解析错误',
+  },
+  base64Codec: {
+    label: '输入内容',
+    placeholder: '输入要编码或解码的内容...',
+    encode: '编码 → Base64',
+    decode: '解码 ← Base64',
+    copy: '复制',
+    clear: '清空',
+    output: '输出结果',
+    errEncode: '编码错误',
+    errDecode: '解码错误: 请输入有效的 Base64 字符串',
+  },
 }
 
 export default zhCN

--- a/src/tools/base64-codec/Base64Codec.vue
+++ b/src/tools/base64-codec/Base64Codec.vue
@@ -2,34 +2,34 @@
   <ToolLayout :tool="toolMeta">
     <div class="base64-tool">
       <div class="panel">
-        <label class="label">输入内容</label>
+        <label class="label">{{ t('base64Codec.label') }}</label>
         <textarea
           v-model="input"
           class="textarea"
-          placeholder="输入要编码或解码的内容..."
+          :placeholder="t('base64Codec.placeholder')"
           rows="8"
         />
       </div>
       <div class="actions">
         <button class="btn primary" @click="encode">
           <ArrowUp :size="16" />
-          编码 → Base64
+          {{ t('base64Codec.encode') }}
         </button>
         <button class="btn" @click="decode">
           <ArrowDown :size="16" />
-          解码 ← Base64
+          {{ t('base64Codec.decode') }}
         </button>
         <button class="btn" @click="copy">
           <Copy :size="16" />
-          复制
+          {{ t('base64Codec.copy') }}
         </button>
         <button class="btn" @click="clear">
           <Trash2 :size="16" />
-          清空
+          {{ t('base64Codec.clear') }}
         </button>
       </div>
       <div class="panel output">
-        <label class="label">输出结果</label>
+        <label class="label">{{ t('base64Codec.output') }}</label>
         <textarea
           v-model="output"
           class="textarea"
@@ -46,8 +46,11 @@
 import { ref } from 'vue'
 import { ArrowUp, ArrowDown, Copy, Trash2 } from 'lucide-vue-next'
 import ToolLayout from '@/components/ToolLayout.vue'
+import { useI18n } from '@/composables/useI18n'
 import type { ToolMeta } from '@/types/tool'
 import Base64Codec from './Base64Codec.vue'
+
+const { t } = useI18n()
 
 const toolMeta: ToolMeta = {
   id: 'base64-codec',
@@ -68,7 +71,7 @@ function encode() {
   try {
     output.value = btoa(unescape(encodeURIComponent(input.value)))
   } catch (e: any) {
-    error.value = `编码错误: ${e.message}`
+    error.value = `${t('base64Codec.errEncode')}: ${e.message}`
     output.value = ''
   }
 }
@@ -78,7 +81,7 @@ function decode() {
   try {
     output.value = decodeURIComponent(escape(atob(input.value)))
   } catch (e: any) {
-    error.value = `解码错误: 请输入有效的 Base64 字符串`
+    error.value = t('base64Codec.errDecode')
     output.value = ''
   }
 }

--- a/src/tools/json-formatter/JsonFormatter.vue
+++ b/src/tools/json-formatter/JsonFormatter.vue
@@ -2,34 +2,34 @@
   <ToolLayout :tool="toolMeta">
     <div class="json-tool">
       <div class="panel">
-        <label class="label">输入 JSON</label>
+        <label class="label">{{ t('jsonFormatter.label') }}</label>
         <textarea
           v-model="input"
           class="textarea"
-          placeholder="粘贴 JSON 内容..."
+          :placeholder="t('jsonFormatter.placeholder')"
           rows="10"
         />
       </div>
       <div class="actions">
         <button class="btn primary" @click="format">
           <Sparkles :size="16" />
-          格式化
+          {{ t('jsonFormatter.format') }}
         </button>
         <button class="btn" @click="minify">
           <Minimize2 :size="16" />
-          压缩
+          {{ t('jsonFormatter.minify') }}
         </button>
         <button class="btn" @click="copy">
           <Copy :size="16" />
-          复制
+          {{ t('jsonFormatter.copy') }}
         </button>
         <button class="btn" @click="clear">
           <Trash2 :size="16" />
-          清空
+          {{ t('jsonFormatter.clear') }}
         </button>
       </div>
       <div class="panel output">
-        <label class="label">输出结果</label>
+        <label class="label">{{ t('jsonFormatter.output') }}</label>
         <textarea
           v-model="output"
           class="textarea"
@@ -46,8 +46,11 @@
 import { ref } from 'vue'
 import { Sparkles, Minimize2, Copy, Trash2 } from 'lucide-vue-next'
 import ToolLayout from '@/components/ToolLayout.vue'
+import { useI18n } from '@/composables/useI18n'
 import type { ToolMeta } from '@/types/tool'
 import JsonFormatter from './JsonFormatter.vue'
+
+const { t } = useI18n()
 
 const toolMeta: ToolMeta = {
   id: 'json-formatter',
@@ -69,7 +72,7 @@ function format() {
     const parsed = JSON.parse(input.value)
     output.value = JSON.stringify(parsed, null, 2)
   } catch (e: any) {
-    error.value = `解析错误: ${e.message}`
+    error.value = `${t('jsonFormatter.errParse')}: ${e.message}`
     output.value = ''
   }
 }
@@ -80,7 +83,7 @@ function minify() {
     const parsed = JSON.parse(input.value)
     output.value = JSON.stringify(parsed)
   } catch (e: any) {
-    error.value = `解析错误: ${e.message}`
+    error.value = `${t('jsonFormatter.errParse')}: ${e.message}`
     output.value = ''
   }
 }

--- a/src/tools/timestamp-converter/TimestampConverter.vue
+++ b/src/tools/timestamp-converter/TimestampConverter.vue
@@ -3,47 +3,47 @@
     <div class="timestamp-tool">
       <div class="grid">
         <div class="panel">
-          <label class="label">时间戳</label>
+          <label class="label">{{ t('timestamp.label') }}</label>
           <input
             v-model="timestamp"
             type="text"
             class="input"
-            placeholder="输入时间戳 (秒或毫秒)"
+            :placeholder="t('timestamp.placeholder')"
           />
           <button class="btn primary" @click="fromTimestamp">
             <ArrowDown :size="16" />
-            转换为日期
+            {{ t('timestamp.toDate') }}
           </button>
         </div>
         <div class="panel">
-          <label class="label">日期时间</label>
+          <label class="label">{{ t('timestamp.dateTime') }}</label>
           <input
             v-model="datetime"
             type="text"
             class="input"
-            placeholder="输入日期 (YYYY-MM-DD HH:mm:ss)"
+            :placeholder="t('timestamp.placeholderDate')"
           />
           <button class="btn" @click="toTimestamp">
             <ArrowUp :size="16" />
-            转换为时间戳
+            {{ t('timestamp.toTimestamp') }}
           </button>
         </div>
       </div>
       <div class="current">
         <div class="current-row">
-          <span class="current-label">当前时间戳</span>
+          <span class="current-label">{{ t('timestamp.currentTs') }}</span>
           <code class="current-value">{{ currentTimestamp }}</code>
           <button class="btn small" @click="copyCurrent">
             <Copy :size="14" />
           </button>
         </div>
         <div class="current-row">
-          <span class="current-label">当前时间</span>
+          <span class="current-label">{{ t('timestamp.currentTime') }}</span>
           <code class="current-value">{{ currentDatetime }}</code>
         </div>
       </div>
       <div class="panel output">
-        <label class="label">转换结果</label>
+        <label class="label">{{ t('timestamp.result') }}</label>
         <div class="result">
           <code class="result-value">{{ result }}</code>
         </div>
@@ -57,8 +57,11 @@
 import { ref, onMounted, onUnmounted } from 'vue'
 import { ArrowUp, ArrowDown, Copy } from 'lucide-vue-next'
 import ToolLayout from '@/components/ToolLayout.vue'
+import { useI18n } from '@/composables/useI18n'
 import type { ToolMeta } from '@/types/tool'
 import TimestampConverter from './TimestampConverter.vue'
+
+const { t } = useI18n()
 
 const toolMeta: ToolMeta = {
   id: 'timestamp-converter',
@@ -108,7 +111,7 @@ function fromTimestamp() {
   result.value = ''
   const ts = timestamp.value.trim()
   if (!ts) {
-    error.value = '请输入时间戳'
+    error.value = t('timestamp.errInput')
     return
   }
   let ms: number
@@ -118,7 +121,7 @@ function fromTimestamp() {
     ms = parseInt(ts) * 1000
   }
   if (isNaN(ms)) {
-    error.value = '无效的时间戳'
+    error.value = t('timestamp.errInvalid')
     return
   }
   result.value = formatDate(ms)
@@ -129,15 +132,15 @@ function toTimestamp() {
   result.value = ''
   const dt = datetime.value.trim()
   if (!dt) {
-    error.value = '请输入日期时间'
+    error.value = t('timestamp.errDatetime')
     return
   }
   const d = new Date(dt)
   if (d.toString() === 'Invalid Date') {
-    error.value = '无效的日期格式'
+    error.value = t('timestamp.errInvalidDate')
     return
   }
-  result.value = Math.floor(d.getTime() / 1000).toString() + ' (秒)\n' + d.getTime().toString() + ' (毫秒)'
+  result.value = Math.floor(d.getTime() / 1000).toString() + ` (${t('timestamp.seconds')})\n` + d.getTime().toString() + ` (${t('timestamp.milliseconds')})`
 }
 
 function copyCurrent() {


### PR DESCRIPTION
## 关联 Issue
Closes #9

## 变更说明

三个工具组件内部的 UI 文本（标签、按钮、placeholder、错误提示）全部为硬编码中文，切换语言后仍然显示中文。

**修复**：
- 语言包补充 timestamp、jsonFormatter、base64Codec 三组翻译 key
- TimestampConverter.vue / JsonFormatter.vue / Base64Codec.vue 模板和脚本全部替换为 t() 调用
- 类型定义同步更新

## 变更类型
- [x] Bug 修复

## 安全检查
- [x] 已检查无敏感信息泄露

## 测试
- [x] 构建通过 (vue-tsc --noEmit)