### PR TITLE
fix: i18n 响应式失效 + 品牌区返回首页

### DIFF
--- a/src/components/AppHeader.vue
+++ b/src/components/AppHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <header class="header">
-    <div class="header-brand">
+    <div class="header-brand" @click="goHome">
       <span class="logo">🔥</span>
       <span class="title">ForgeX</span>
     </div>
@@ -32,6 +32,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
+import { useRouter } from 'vue-router'
 import { Search, Menu, Sun, Moon } from 'lucide-vue-next'
 import { useToolsStore } from '@/stores/tools'
 import { useThemeStore } from '@/stores/theme'
@@ -39,6 +40,7 @@ import { useLocaleStore } from '@/stores/locale'
 import { useI18n } from '@/composables/useI18n'
 
 const emit = defineEmits(['toggle-sidebar'])
+const router = useRouter()
 const store = useToolsStore()
 const storeTheme = useThemeStore()
 const storeLocale = useLocaleStore()
@@ -58,6 +60,10 @@ function handleKeydown(e: KeyboardEvent) {
 
 function focusSearch() {
   document.querySelector<HTMLInputElement>('.search-input')?.focus()
+}
+
+function goHome() {
+  router.push('/')
 }
 
 onMounted(() => {
@@ -88,6 +94,8 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
+  cursor: pointer;
+  user-select: none;
 }
 
 .logo { font-size: 20px; }

--- a/src/composables/useI18n.ts
+++ b/src/composables/useI18n.ts
@@ -1,4 +1,14 @@
 import { useLocaleStore } from '@/stores/locale'
+import type { LocaleMessages } from '@/locales/types'
+import zhCN from '@/locales/zh-CN'
+import en from '@/locales/en'
+
+type Locale = 'zh-CN' | 'en'
+
+const messages: Record<Locale, LocaleMessages> = {
+  'zh-CN': zhCN,
+  'en': en,
+}
 
 /**
  * Lightweight i18n composable.
@@ -6,8 +16,8 @@ import { useLocaleStore } from '@/stores/locale'
  * Usage:
  * ```ts
  * const { t, locale, toggleLocale } = useI18n()
- * t('search')           // => "搜索工具..."
- * t('categories.encode') // => "编码转换"
+ * t('search')                  // => "搜索工具..."
+ * t('categories.encode')       // => "编码转换"
  * t('tools.timestampConverter') // => "时间戳转换"
  * ```
  */
@@ -16,12 +26,16 @@ export function useI18n() {
 
   /**
    * Translate a dot-separated key path.
-   * Supports nested access and template interpolation:
-   * t('welcome', { name: 'ForgeX' })
+   * Depends on store.locale (a ref) so any computed using t() will
+   * reactively re-evaluate when locale changes.
    */
   function t(key: string, params?: Record<string, string>, fallback?: string): string {
+    // Access store.locale to create a reactive dependency for computed
+    const _locale = store.locale
+    const messages_ = messages[_locale]
+
     const parts = key.split('.')
-    let value: any = store.t
+    let value: any = messages_
     for (const part of parts) {
       if (value == null || typeof value !== 'object') {
         return fallback ?? key

--- a/src/stores/locale.ts
+++ b/src/stores/locale.ts
@@ -1,34 +1,20 @@
 import { ref, watch } from 'vue'
 import { defineStore } from 'pinia'
-import type { LocaleMessages } from '@/locales/types'
-import zhCN from '@/locales/zh-CN'
-import en from '@/locales/en'
 
 export type Locale = 'zh-CN' | 'en'
 
 const STORAGE_KEY = 'forgex-locale'
 
-const messages: Record<Locale, LocaleMessages> = {
-  'zh-CN': zhCN,
-  'en': en,
-}
-
 export const useLocaleStore = defineStore('locale', () => {
   function getInitialLocale(): Locale {
     const stored = localStorage.getItem(STORAGE_KEY)
     if (stored === 'zh-CN' || stored === 'en') return stored
-    // Default to browser language if available
     const lang = navigator.language
     if (lang.startsWith('zh')) return 'zh-CN'
     return 'en'
   }
 
   const locale = ref<Locale>(getInitialLocale())
-  const t = ref<LocaleMessages>(messages[locale.value])
-
-  function updateMessages(l: Locale) {
-    t.value = messages[l]
-  }
 
   function toggleLocale() {
     locale.value = locale.value === 'zh-CN' ? 'en' : 'zh-CN'
@@ -40,10 +26,8 @@ export const useLocaleStore = defineStore('locale', () => {
 
   watch(locale, (l) => {
     localStorage.setItem(STORAGE_KEY, l)
-    updateMessages(l)
-    // Update html lang attribute
     document.documentElement.setAttribute('lang', l)
   }, { immediate: true })
 
-  return { locale, t, toggleLocale, setLocale }
+  return { locale, toggleLocale, setLocale }
 })


### PR DESCRIPTION
## 关联 Issue
Closes #11

## 变更说明

### Bug 1: 切换语言后工具名称/描述不更新
**根因**：`useI18n` 的 `t()` 函数依赖 `store.t`（Pinia unwrap 后的普通对象），不是响应式的，computed 无法追踪变化。
**修复**：`t()` 改为依赖 `store.locale` ref，通过 `messages[locale]` 直接取翻译，computed 正确追踪 locale 变化。

### Bug 2: 品牌区点击无响应
**修复**：`@click="goHome()"` 跳转首页，加 cursor:pointer 样式。

## 变更类型
- [x] Bug 修复

## 测试
- [x] 构建通过 (vue-tsc --noEmit)