### PR TITLE
fix: useI18n 中 store.locale 需用 storeToRefs 解构才能追踪响应式

### DIFF
--- a/src/composables/useI18n.ts
+++ b/src/composables/useI18n.ts
@@ -1,4 +1,5 @@
 import { useLocaleStore } from '@/stores/locale'
+import { storeToRefs } from 'pinia'
 import type { LocaleMessages } from '@/locales/types'
 import zhCN from '@/locales/zh-CN'
 import en from '@/locales/en'
@@ -23,15 +24,16 @@ const messages: Record<Locale, LocaleMessages> = {
  */
 export function useI18n() {
   const store = useLocaleStore()
+  const { locale } = storeToRefs(store)
 
   /**
    * Translate a dot-separated key path.
-   * Depends on store.locale (a ref) so any computed using t() will
-   * reactively re-evaluate when locale changes.
+   * Depends on the locale ref (via storeToRefs) so any computed using t()
+   * will reactively re-evaluate when locale changes.
    */
   function t(key: string, params?: Record<string, string>, fallback?: string): string {
-    // Access store.locale to create a reactive dependency for computed
-    const _locale = store.locale
+    // Access locale.value to register reactive dependency in computed
+    const _locale = locale.value
     const messages_ = messages[_locale]
 
     const parts = key.split('.')
@@ -53,7 +55,7 @@ export function useI18n() {
 
   return {
     t,
-    locale: store.locale,
+    locale,
     toggleLocale: store.toggleLocale,
     setLocale: store.setLocale,
   }


### PR DESCRIPTION
## 关联 Issue
Ref #11（补充修复）

## 变更说明

**根因**：Pinia 的 setup store 在访问属性时会对 ref 自动 unwrap。 直接拿到的是普通字符串值 ，而不是 ref。computed 中的 `t()` 函数读取的是普通字符串，无法建立响应式追踪。

**修复**：用 `storeToRefs(store).locale` 获取原始 ref，再通过 `.value` 读取，这样 computed 就能正确追踪 locale 变化。

## 变更类型
- [x] Bug 修复

## 测试
- [x] 构建通过 (vue-tsc --noEmit)