### PR TITLE
fix(i18n): 修复工具卡片和详情页文案不响应语言切换

### DIFF
--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -24,12 +24,12 @@ const en: LocaleMessages = {
     switchToEn: 'Switch to English',
   },
   tools: {
-    timestampConverter: 'Timestamp Converter',
-    timestampConverterDesc: 'Convert between Unix timestamp and date',
-    jsonFormatter: 'JSON Formatter',
-    jsonFormatterDesc: 'Format, minify and validate JSON',
-    base64Codec: 'Base64 Encoder/Decoder',
-    base64CodecDesc: 'Encode and decode Base64',
+    'timestamp-converter': 'Timestamp Converter',
+    'timestamp-converterDesc': 'Convert between Unix timestamp and date',
+    'json-formatter': 'JSON Formatter',
+    'json-formatterDesc': 'Format, minify and validate JSON',
+    'base64-codec': 'Base64 Encoder/Decoder',
+    'base64-codecDesc': 'Encode and decode Base64',
   },
 
   /* Tool internal UI text */

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -22,12 +22,12 @@ export interface LocaleMessages {
     switchToEn: string
   }
   tools: {
-    timestampConverter: string
-    timestampConverterDesc: string
-    jsonFormatter: string
-    jsonFormatterDesc: string
-    base64Codec: string
-    base64CodecDesc: string
+    'timestamp-converter': string
+    'timestamp-converterDesc': string
+    'json-formatter': string
+    'json-formatterDesc': string
+    'base64-codec': string
+    'base64-codecDesc': string
   }
   timestamp: {
     label: string

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -24,12 +24,12 @@ const zhCN: LocaleMessages = {
     switchToEn: '切换到英文',
   },
   tools: {
-    timestampConverter: '时间戳转换',
-    timestampConverterDesc: 'Unix 时间戳与日期互转',
-    jsonFormatter: 'JSON 格式化',
-    jsonFormatterDesc: '格式化、压缩和校验 JSON',
-    base64Codec: 'Base64 编解码',
-    base64CodecDesc: 'Base64 编码与解码',
+    'timestamp-converter': '时间戳转换',
+    'timestamp-converterDesc': 'Unix 时间戳与日期互转',
+    'json-formatter': 'JSON 格式化',
+    'json-formatterDesc': '格式化、压缩和校验 JSON',
+    'base64-codec': 'Base64 编解码',
+    'base64-codecDesc': 'Base64 编码与解码',
   },
 
   /* 工具内部 UI 文本 */


### PR DESCRIPTION
## 关联 Issue
Closes #14

## 变更说明
locale 文件中的 tools key 从 camelCase 改为 kebab-case，与工具 ID 一致，修复 i18n 查找不到翻译永远 fallback 硬编码中文的问题。

## 变更类型
- [x] Bug 修复

## 安全检查
- [x] 已检查无 API Key / Token 硬编码
- [x] 已检查无个人隐私信息泄露
- [x] 已检查无内网地址暴露
- [x] .env / 敏感配置未纳入版本控制
- [x] 调试代码已清理

## 测试
- [x] TypeScript 编译通过
- [x] 独立 reviewer 审查通过

## 改动文件
- src/locales/zh-CN.ts
- src/locales/en.ts
- src/locales/types.ts