### PR TITLE
fix: 工具卡片分类标签跟随国际化切换

### DIFF
--- a/src/components/ToolCard.vue
+++ b/src/components/ToolCard.vue
@@ -28,7 +28,7 @@ const icon = computed(() => (LucideIcons as any)[props.tool.icon] || LucideIcons
 const localizedName = computed(() => t(`tools.${props.tool.id}`, {}, props.tool.name))
 const localizedDesc = computed(() => t(`tools.${props.tool.id}Desc`, {}, props.tool.description))
 const categoryLabel = computed(() =>
-  store.categories.find(c => c.id === props.tool.category)?.label || props.tool.category
+  t(`categories.${props.tool.category}`, {}, props.tool.category)
 )
 
 function navigate() {


### PR DESCRIPTION
### 修复内容
- 修复工具卡片上分类标签（编码转换、格式化等）不随语言切换的问题
- 修改 ToolCard.vue 中 categoryLabel 计算属性的实现
- 改为通过 i18n 的 `t()` 函数获取翻译值：`t("categories.${props.tool.category}")`

### 验证
- TypeScript 编译通过：`npx vue-tsc --noEmit` ✅
- 安全静态扫描通过 ✅